### PR TITLE
Delete .spectral.yml

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,6 +1,0 @@
-extends:
-- https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/.spectral.yml
-rules:
-  oas3-valid-oas-parameter-example: off
-  oas3-valid-oas-content-example: off
-  no-$ref-siblings: off


### PR DESCRIPTION
De repo bevat geen openapi.yaml dus .spectral.yml kan worden verwijderd.